### PR TITLE
use json endpoint for version check

### DIFF
--- a/bmlt-meeting-list.php
+++ b/bmlt-meeting-list.php
@@ -5,7 +5,7 @@ Plugin URI: http://wordpress.org/extend/plugins/bread/
 Description: Maintains and generates a PDF Meeting List from BMLT.
 Author: bmlt-enabled
 Author URI: https://bmlt.app
-Version: 2.5.8
+Version: 2.5.9
 */
 /* Disallow direct access to the plugin file */
 use Mpdf\Mpdf;
@@ -439,19 +439,17 @@ if (!class_exists("Bread")) {
 		
 		function testRootServer($override_root_server = null) {
 			if ($override_root_server == null) {
-				$results = $this->get_configured_root_server_request("client_interface/serverInfo.xml");
+				$results = $this->get_configured_root_server_request("client_interface/json/?switcher=GetServerInfo");
 			} else {
-				$results = $this->get_root_server_request($override_root_server."/client_interface/serverInfo.xml");
+				$results = $this->get_root_server_request($override_root_server."/client_interface/json/?switcher=GetServerInfo");
 			}
 			$httpcode = wp_remote_retrieve_response_code($results);
 			if ($httpcode != 200 && $httpcode != 302 && $httpcode != 304) {
 				return false;
 			}
-			$results = simplexml_load_string(wp_remote_retrieve_body($results));
-			$results = json_encode($results);
-			$results = json_decode($results,TRUE);
-			$results = $results["serverVersion"]["readableString"];
-			return $results;
+            $result = json_decode(wp_remote_retrieve_body($results), true);
+            $result = $result[0]["version"];
+			return $result;
 		}
 		// This is used from the AdminUI, not to generate the
 		// meeting list.

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Requires at least: 4.0
 
 Requires PHP: 7.1
 Tested up to: 5.6.1
-Stable tag: 2.5.8
+Stable tag: 2.5.9
 
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -55,6 +55,9 @@ Follow all these steps, keep in mind that once you start using bread, it's not g
 - Read here for more information: https://github.com/bmlt-enabled/bread/blob/unstable/contribute.md
 
 == Changelog ==
+
+= 2.5.9 =
+* Using json endpoint for version checking.
 
 = 2.5.7 =
 * Fixed problem with Caching


### PR DESCRIPTION
I know at least one service body was failing to connect due to having issues pulling the `serverInfo.xml` file. this will instead get the version from the server info json endpoint. as well as stay consistent with api calls.