### PR TITLE
add a shortcode for format legends in French

### DIFF
--- a/bmlt-meeting-list.php
+++ b/bmlt-meeting-list.php
@@ -5,7 +5,7 @@ Plugin URI: http://wordpress.org/extend/plugins/bread/
 Description: Maintains and generates a PDF Meeting List from BMLT.
 Author: bmlt-enabled
 Author URI: https://bmlt.app
-Version: 2.6.4
+Version: 2.6.5
 */
 /* Disallow direct access to the plugin file */
 use Mpdf\Mpdf;
@@ -965,6 +965,16 @@ if (!class_exists("Bread")) {
 				$this->formats_spanish = $result_es['formats'];
 				$this->sortBySubkey($this->formats_spanish, 'key_string');
 			}
+			if ( strpos($this->options['custom_section_content'].$this->options['front_page_content'].$this->options['last_page_content'], '[format_codes_used_basic_fr') !== false ) {
+				if ( $this->options['used_format_1'] == '' ) {
+					$results = $this->get_configured_root_server_request("client_interface/json/?switcher=GetSearchResults$services&sort_keys=time$get_used_formats&lang_enum=fr" );
+				} else {
+					$results = $this->get_configured_root_server_request("client_interface/json/?switcher=GetSearchResults$services&sort_keys=time&get_used_formats&lang_enum=fr&formats[]=".$this->options['used_format_1'] );
+				}
+				$result_fr = json_decode(wp_remote_retrieve_body($results), true);
+				$this->formats_french = $result_fr['formats'];
+				$this->sortBySubkey($this->formats_french, 'key_string');
+			}
 			
 			if ( $this->options['include_asm'] === '0' ) {
 				$countmax = count ( $this->formats_used );
@@ -1783,6 +1793,7 @@ if (!class_exists("Bread")) {
 			$this->shortcode_formats('[format_codes_used_detailed]', true, $this->formats_used, $page_name, $data);
 			$this->shortcode_formats('[format_codes_used_basic_es]', false, $this->formats_spanish, $page_name, $data);
 			$this->shortcode_formats('[format_codes_used_detailed_es]', true, $this->formats_spanish, $page_name, $data);
+			$this->shortcode_formats('[format_codes_used_basic_fr]', false, $this->formats_french, $page_name, $data);
 			$this->shortcode_formats('[format_codes_all_basic]', false, $this->formats_all, $page_name, $data);
 			$this->shortcode_formats('[format_codes_all_detailed]', true, $this->formats_all, $page_name, $data);
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -1,12 +1,12 @@
 === bread ===
 
-Contributors: odathp, radius314, pjaudiomv, klgrimley, jbraswell, otrok7
+Contributors: odathp, radius314, pjaudiomv, klgrimley, jbraswell, otrok7, alanb2718
 Tags: meeting list, bmlt, narcotics anonymous, na
 Requires at least: 4.0
 Requires PHP: 7.1
 Requires at least: 5.1
 Tested up to: 5.9
-Stable tag: 2.6.4
+Stable tag: 2.6.5
 
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -55,6 +55,9 @@ Follow all these steps, keep in mind that once you start using bread, it's not g
 - Read here for more information: https://github.com/bmlt-enabled/bread/blob/unstable/contribute.md
 
 == Changelog ==
+= 2.6.5 =
+* Add a shortcode for format legends in French [format_codes_used_basic_fr]
+
 = 2.6.4 =
 * Fixed an issue with plugin activation when using PHP8.
 * Upgraded to mPDF 8.0.17

--- a/tinymce/front_page_button/plugin.min.js
+++ b/tinymce/front_page_button/plugin.min.js
@@ -56,6 +56,12 @@
 							}
 						},
 						{
+							text: 'Used Format Codes - Abbreviated - French',
+							onclick: function() {
+								editor.insertContent('<table style="width: 100%;"><tbody><tr><td style="padding: 2pt; text-align: center; background-color: #000000;"><strong><span style="color: #fff;">Légende format de réunion</span></strong></td></tr></tbody></table><p>[format_codes_used_basic_fr]</p>');
+							}
+						},
+						{
 							text: 'Used Format Codes - Detailed - English',
 							onclick: function() {
 								editor.insertContent('<table style="width: 100%;"><tbody><tr><td style="padding: 2pt; text-align: center; background-color: #000000;"><strong><span style="color: #fff;">Meeting Format Legend</span></strong></td></tr></tbody></table><p>[format_codes_used_detailed]</p>');


### PR DESCRIPTION
This responds to a request for French format legends.  It adds a shortcode `[format_codes_used_basic_fr]` in analogy with an existing one for Spanish [`format_codes_used_basic_es]`.  There is also a variant for detailed format codes in Spanish `[format_codes_used_detailed_es]` but it doesn't work -- so I didn't add duplicate code that wouldn't work in French either.  I'll add an issue that notes this bug and that suggests a better way to handle these legends.